### PR TITLE
Need to get the latest version of nuget.exe for package restore

### DIFF
--- a/components/run.ps1
+++ b/components/run.ps1
@@ -8,7 +8,7 @@ $nugetPath = ".\src\.nuget\"
 if((Test-Path -Path "$nugetPath\nuget.exe") -eq $false){
     Write-Host "Downloading nuget to $nugetPath"
     New-Item -ItemType Directory -Path $nugetPath -Force | Out-Null
-    Invoke-WebRequest -Uri "https://www.nuget.org/nuget.exe" -OutFile "$nugetPath\nuget.exe" | Out-Null
+    Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile "$nugetPath\nuget.exe" | Out-Null
 }
 
 $psakePath = ".\tools\psake\4.6.0\psake.psm1"


### PR DESCRIPTION
https://www.nuget.org/nuget.exe does not provide the latest version.  
I was getting errors trying to execute run until I made this change.